### PR TITLE
Fix a segfault when EventProcessor is dropped without shutdown call

### DIFF
--- a/zeroconf-tokio/src/browser.rs
+++ b/zeroconf-tokio/src/browser.rs
@@ -83,6 +83,12 @@ impl MdnsBrowserAsync {
     }
 }
 
+impl Drop for MdnsBrowserAsync {
+    fn drop(&mut self) {
+        self.event_processor.sync_shutdown();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use ntest::timeout;

--- a/zeroconf-tokio/src/event_processor.rs
+++ b/zeroconf-tokio/src/event_processor.rs
@@ -87,6 +87,18 @@ impl EventProcessor {
 
         Ok(())
     }
+
+    pub(crate) fn sync_shutdown(&mut self) {
+        self.running.store(false, Ordering::Relaxed);
+
+        if let Some(join_handle) = self.join_handle.take() {
+            join_handle.abort();
+
+            while !join_handle.is_finished() {
+                std::hint::spin_loop();
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/zeroconf-tokio/src/service.rs
+++ b/zeroconf-tokio/src/service.rs
@@ -75,6 +75,12 @@ impl MdnsServiceAsync {
     }
 }
 
+impl Drop for MdnsServiceAsync {
+    fn drop(&mut self) {
+        self.event_processor.sync_shutdown();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## What
A `*mut` pointer into libavahi-land could become invalid when an `EventProcessor` is dropped without having called `shutdown` on it first. This could lead to a segmentation fault or other error in libavahi.

### Service example:

```rust
    let mut service = MdnsServiceAsync::new(...).unwrap();
    service.start().await.unwrap();
    drop(service);
```

### Browser example:

```rust
    let mut browser = MdnsBrowserAsync::new(...).unwrap();
    browser.start().await.unwrap();
    drop(browser);
```

The underlying chain of events was this:

* the `MdnsServiceAsync` or `MdnsBrowserAsync` is dropped
* it held a reference to some `*mut` pointer into libavahi
* the `running` member of the `EventProcessor` is never set to `false`, so it continues to call `poll`
* the pointer into C-land is now invalid, causing a crash


## Why
Adding a synchronous shutdown-alternative to `EventProcessor` and calling it from a `Drop` implementation for `MdnsServiceAsync` and `MdnsBrowserAsync` fixes this, as the poll-loop is stopped before the pointer is invalidated.

## Manual Tests
I ran the minimal example described above multiple times. The segfault happened about 50% of the time without my fix, and I was unable to produce a segfault or similar crash with my change.

## Documentation Updates
I did not really document anything; I was hoping my changes were self-explanatory.
