### PR TITLE
refactor: using future steam trait for browser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,16 +377,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "futures-core"
-version = "0.3.30"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "gimli"
@@ -655,6 +731,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "env_logger",
+ "futures",
  "log",
  "tokio",
  "zeroconf-tokio",
@@ -696,6 +773,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "strsim"
@@ -915,6 +998,7 @@ dependencies = [
 name = "zeroconf-tokio"
 version = "0.3.2"
 dependencies = [
+ "futures",
  "log",
  "ntest",
  "tokio",

--- a/examples/register-and-discover/Cargo.toml
+++ b/examples/register-and-discover/Cargo.toml
@@ -9,4 +9,5 @@ clap = { version = "4.5.11", features = ["derive"] }
 env_logger = "0.11.5"
 log = "0.4.22"
 tokio = { version = "1.39.2", features = ["rt-multi-thread", "macros"] }
+futures = "0.3"
 zeroconf-tokio = { path = "../../zeroconf-tokio" }

--- a/examples/register-and-discover/src/main.rs
+++ b/examples/register-and-discover/src/main.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 use clap::Parser;
+use futures::StreamExt;
 use zeroconf_tokio::prelude::*;
 use zeroconf_tokio::{
     BrowserEvent, MdnsBrowser, MdnsBrowserAsync, MdnsService, MdnsServiceAsync, ServiceType,

--- a/zeroconf-tokio/Cargo.toml
+++ b/zeroconf-tokio/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.39.1", features = [
     "rt-multi-thread",
 ] }
 tokio-util = "0.7.11"
+futures = "0.3"
 zeroconf = { path = "../../zeroconf-rs/zeroconf", version = "0.18.0" }
 
 [dev-dependencies]

--- a/zeroconf-tokio/src/browser.rs
+++ b/zeroconf-tokio/src/browser.rs
@@ -1,8 +1,12 @@
 //! Asynchronous mDNS browser.
 
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
 use std::time::Duration;
 
+use futures::Stream;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use zeroconf::prelude::*;
@@ -64,21 +68,27 @@ impl MdnsBrowserAsync {
         self.start_with_timeout(Duration::ZERO).await
     }
 
-    /// Get the next browser event or `None` if the browser is not running.
-    pub async fn next(&mut self) -> Option<zeroconf::Result<BrowserEvent>> {
-        if !self.event_processor.is_running() {
-            return None;
-        }
-
-        self.receiver.recv().await
-    }
-
     /// Shutdown the browser.
     pub async fn shutdown(&mut self) -> zeroconf::Result<()> {
         info!("Shutting down browser...");
         self.event_processor.shutdown().await?;
         info!("Browser shut down");
         Ok(())
+    }
+}
+
+impl Stream for MdnsBrowserAsync {
+    type Item = zeroconf::Result<BrowserEvent>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        if !this.event_processor.is_running() {
+            return Poll::Ready(None);
+        }
+        if let Poll::Ready(event) = this.receiver.poll_recv(cx) {
+            return Poll::Ready(event);
+        }
+        Poll::Pending
     }
 }
 
@@ -90,6 +100,7 @@ impl Drop for MdnsBrowserAsync {
 
 #[cfg(test)]
 mod tests {
+    use futures::StreamExt;
     use ntest::timeout;
     use zeroconf::MdnsService;
     use zeroconf::ServiceType;


### PR DESCRIPTION
## What
Refactor `MdnsBrowserAsync` to implement the `futures::Stream` trait, allowing browser events to be consumed with standard stream APIs like `StreamExt::next()`.

Also updates the register-and-discover example and tests to use `futures::StreamExt`, and adds the `futures` dependency.

## Why
Using the standard `Stream` trait makes `MdnsBrowserAsync` easier to compose with the Rust async ecosystem instead of relying on a custom `next()` method.

This also keeps event consumption consistent with common async patterns and supports usage inside spawned async tasks.

## Manual Tests
Not run in this session.

## Documentation Updates
No README updates were added. The code remains self-explanatory and uses the standard `Stream` implementation pattern for polling browser events.